### PR TITLE
Preserve user-configured splitter filters

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -11,9 +11,9 @@ local function on_splitter_placed(splitter)
   local has_left = splitter_utils.has_compatible_entity_at(surface, left_pos, dir)
   local has_right = splitter_utils.has_compatible_entity_at(surface, right_pos, dir)
 
-  if has_left and not has_right then
+  if has_left and not has_right and not splitter.splitter_filter then
     splitter_utils.set_block_filter(splitter, "right")
-  elseif has_right and not has_left then
+  elseif has_right and not has_left and not splitter.splitter_filter then
     splitter_utils.set_block_filter(splitter, "left")
   end
 end
@@ -29,11 +29,11 @@ local function on_transport_placed(entity)
       local has_left = splitter_utils.has_compatible_entity_at(surface, left_pos, dir)
       local has_right = splitter_utils.has_compatible_entity_at(surface, right_pos, dir)
 
-      if has_left and has_right and splitter.splitter_filter then
+      if has_left and has_right and splitter_utils.has_block_filter(splitter) then
         splitter_utils.clear_block_filter(splitter)
-      elseif has_left and not has_right then
+      elseif has_left and not has_right and not splitter.splitter_filter then
         splitter_utils.set_block_filter(splitter, "right")
-      elseif has_right and not has_left then
+      elseif has_right and not has_left and not splitter.splitter_filter then
         splitter_utils.set_block_filter(splitter, "left")
       end
     end
@@ -52,7 +52,9 @@ local function on_transport_removed(entity)
       local has_right = splitter_utils.has_compatible_entity_at(surface, right_pos, dir, entity)
 
       if not has_left and not has_right then
-        splitter_utils.clear_block_filter(splitter)
+        if splitter_utils.has_block_filter(splitter) then
+          splitter_utils.clear_block_filter(splitter)
+        end
       elseif has_left and not has_right and not splitter.splitter_filter then
         splitter_utils.set_block_filter(splitter, "right")
       elseif has_right and not has_left and not splitter.splitter_filter then

--- a/lib/splitter_utils.lua
+++ b/lib/splitter_utils.lua
@@ -85,6 +85,13 @@ function splitter_utils.find_affecting_splitters(entity)
   return result
 end
 
+function splitter_utils.has_block_filter(splitter)
+  local filter = splitter.splitter_filter
+  if not filter then return false end
+  local name = type(filter) == "string" and filter or filter.name
+  return name == BLOCK_FILTER
+end
+
 function splitter_utils.set_block_filter(splitter, side)
   splitter.splitter_filter = BLOCK_FILTER
   splitter.splitter_output_priority = side


### PR DESCRIPTION
## Summary
- Add `has_block_filter()` to check if the current filter matches the MOD's block filter item
- Only clear or set block filters when no user-configured filter is present
- Applies to all three handlers: `on_splitter_placed`, `on_transport_placed`, `on_transport_removed`

## Test plan
- [ ] Place a splitter with a user-configured filter where only one output has a belt — filter should not be overwritten
- [ ] Paste a blueprint containing a splitter with a user filter at a location with one-sided output — filter should be preserved
- [ ] Remove a belt from a splitter with a user filter — filter should not be cleared
- [ ] Verify normal block filter behavior still works for splitters without user filters

Fixes #3