### PR TITLE
:sparkles: Use no-item as default block filter item

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: Unreleased
+  Changes:
+    - Use no-item as default block filter item for cleaner appearance
+    - Setting is now always visible in MOD settings
+---------------------------------------------------------------------------------------------------
 Version: 0.5.0
 Date: 2026-02-26
   Features:

--- a/locale/en/auto-splitter-block.cfg
+++ b/locale/en/auto-splitter-block.cfg
@@ -11,5 +11,6 @@ auto-splitter-block-filter-item=Block filter item
 auto-splitter-block-filter-item=The item to use as the splitter output filter for blocking. This item should never appear on belts.
 
 [string-mod-setting]
+auto-splitter-block-filter-item-no-item=[item=no-item] __ITEM__no-item__
 auto-splitter-block-filter-item-deconstruction-planner=[item=deconstruction-planner] __ITEM__deconstruction-planner__
 auto-splitter-block-filter-item-atan-null=[item=atan-null] __ITEM__atan-null__

--- a/settings.lua
+++ b/settings.lua
@@ -2,8 +2,8 @@ local setting = {
   type = "string-setting",
   name = "auto-splitter-block-filter-item",
   setting_type = "startup",
-  default_value = "deconstruction-planner",
-  allowed_values = {"deconstruction-planner"},
+  default_value = "no-item",
+  allowed_values = {"no-item", "deconstruction-planner"},
   order = "a",
 }
 
@@ -11,7 +11,5 @@ if mods["atan-null"] then
   table.insert(setting.allowed_values, "atan-null")
   setting.default_value = "atan-null"
 end
-
-setting.hidden = #setting.allowed_values <= 1
 
 data:extend({setting})


### PR DESCRIPTION
## Summary
Use the base game's hidden `no-item` as the default block filter item instead of `deconstruction-planner` for a cleaner appearance.

## Changes
- Change default block filter item from `deconstruction-planner` to `no-item`
- Add `no-item` to allowed values in settings
- Remove `hidden` setting logic (setting is now always visible with multiple choices)
- Add locale entry for `no-item`

Closes #8
