### PR TITLE
:bug: Disable auto-blocking for automated builds by default

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,10 @@ Version: Unreleased
   Changes:
     - Use no-item as default block filter item for cleaner appearance
     - Setting is now always visible in MOD settings
+  Bugfixes:
+    - Disable auto-blocking for robot and space platform builds by default to prevent overwriting blueprint-configured splitter filters
+  Features:
+    - Add runtime setting to enable auto-blocking for robot and space platform builds
 ---------------------------------------------------------------------------------------------------
 Version: 0.5.0
 Date: 2026-02-26

--- a/control.lua
+++ b/control.lua
@@ -64,6 +64,10 @@ local function on_transport_removed(entity)
   end
 end
 
+local function is_automated_build_enabled()
+  return settings.global["auto-splitter-block-enable-for-automated-builds"].value
+end
+
 local function on_entity_built(event)
   local entity = event.entity
   if entity.type == "splitter" then
@@ -74,11 +78,21 @@ local function on_entity_built(event)
   end
 end
 
+local function on_entity_built_automated(event)
+  if not is_automated_build_enabled() then return end
+  on_entity_built(event)
+end
+
 local function on_entity_removed(event)
   local entity = event.entity
   if entity_utils.is_transport_entity(entity) then
     on_transport_removed(entity)
   end
+end
+
+local function on_entity_removed_automated(event)
+  if not is_automated_build_enabled() then return end
+  on_entity_removed(event)
 end
 
 local ENTITY_FILTER = {
@@ -90,9 +104,9 @@ local ENTITY_FILTER = {
 }
 
 script.on_event(defines.events.on_built_entity, on_entity_built, ENTITY_FILTER)
-script.on_event(defines.events.on_robot_built_entity, on_entity_built, ENTITY_FILTER)
-script.on_event(defines.events.on_space_platform_built_entity, on_entity_built, ENTITY_FILTER)
+script.on_event(defines.events.on_robot_built_entity, on_entity_built_automated, ENTITY_FILTER)
+script.on_event(defines.events.on_space_platform_built_entity, on_entity_built_automated, ENTITY_FILTER)
 
 script.on_event(defines.events.on_player_mined_entity, on_entity_removed, ENTITY_FILTER)
-script.on_event(defines.events.on_robot_mined_entity, on_entity_removed, ENTITY_FILTER)
-script.on_event(defines.events.on_space_platform_mined_entity, on_entity_removed, ENTITY_FILTER)
+script.on_event(defines.events.on_robot_mined_entity, on_entity_removed_automated, ENTITY_FILTER)
+script.on_event(defines.events.on_space_platform_mined_entity, on_entity_removed_automated, ENTITY_FILTER)

--- a/locale/en/auto-splitter-block.cfg
+++ b/locale/en/auto-splitter-block.cfg
@@ -6,9 +6,11 @@ auto-splitter-block=Automatically sets splitter output filters to block the unus
 
 [mod-setting-name]
 auto-splitter-block-filter-item=Block filter item
+auto-splitter-block-enable-for-automated-builds=Enable for automated builds
 
 [mod-setting-description]
 auto-splitter-block-filter-item=The item to use as the splitter output filter for blocking. This item should never appear on belts.
+auto-splitter-block-enable-for-automated-builds=Apply auto-blocking when entities are built by __ENTITY__construction-robot__ or __TECHNOLOGY__space-platform__. Disable this if blueprint-configured splitter filters are being overwritten.
 
 [string-mod-setting]
 auto-splitter-block-filter-item-no-item=[item=no-item] __ITEM__no-item__

--- a/locale/ja/auto-splitter-block.cfg
+++ b/locale/ja/auto-splitter-block.cfg
@@ -1,5 +1,7 @@
 [mod-setting-name]
 auto-splitter-block-filter-item=ブロック用フィルターアイテム
+auto-splitter-block-enable-for-automated-builds=自動建設時にも有効にする
 
 [mod-setting-description]
 auto-splitter-block-filter-item=分配器の出力ブロックに使用するアイテム。ベルト上に出現しないアイテムを指定します。
+auto-splitter-block-enable-for-automated-builds=__ENTITY__construction-robot__や__TECHNOLOGY__space-platform__による建設時にも自動ブロックを適用します。建設計画で設定したフィルターが上書きされる場合は無効にしてください。

--- a/settings.lua
+++ b/settings.lua
@@ -12,4 +12,13 @@ if mods["atan-null"] then
   setting.default_value = "atan-null"
 end
 
-data:extend({setting})
+data:extend({
+  setting,
+  {
+    type = "bool-setting",
+    name = "auto-splitter-block-enable-for-automated-builds",
+    setting_type = "runtime-global",
+    default_value = false,
+    order = "b",
+  },
+})


### PR DESCRIPTION
## Summary

Disable auto-blocking for robot and space platform builds by default to prevent overwriting blueprint-configured splitter filters.

## Changes

- Add `auto-splitter-block-enable-for-automated-builds` runtime-global setting (default: off)
- Separate event handlers for player builds vs automated builds

Fixes #10
Related to #6
