### PR TITLE
:sparkles: Support Null MOD as block filter item option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ A Factorio 2.0 MOD that automatically sets splitter output filters to block the 
 
 ## Block Filter Item
 
-The item used for blocking is configurable in MOD settings (startup).
+The item used for blocking is configurable in MOD settings (startup). Default: No item.
 
-- Default: Deconstruction planner
-- With [Null Item](https://mods.factorio.com/mod/atan-null) installed: Null item (default)
+Additional options with optional mods:
+
+- [Null Item](https://mods.factorio.com/mod/atan-null)
+- [Null](https://mods.factorio.com/mod/null) (listed as "Null Item/Entity" on the mod portal)
 
 ## Compatible Transport Entities
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ Version: Unreleased
   Features:
     - Add runtime setting to enable auto-blocking for robot and space platform builds
     - Re-evaluate block filters when splitters or transport entities are rotated or flipped
+    - Support Null MOD as block filter item option
 ---------------------------------------------------------------------------------------------------
 Version: 0.5.0
 Date: 2026-02-26

--- a/info.json
+++ b/info.json
@@ -8,6 +8,7 @@
   "dependencies": [
     "base >= 2.0",
     "(?) space-age",
-    "(?) atan-null"
+    "(?) atan-null",
+    "(?) null"
   ]
 }

--- a/locale/en/auto-splitter-block.cfg
+++ b/locale/en/auto-splitter-block.cfg
@@ -15,4 +15,5 @@ auto-splitter-block-enable-for-automated-builds=Apply auto-blocking when entitie
 [string-mod-setting]
 auto-splitter-block-filter-item-no-item=[item=no-item] __ITEM__no-item__
 auto-splitter-block-filter-item-deconstruction-planner=[item=deconstruction-planner] __ITEM__deconstruction-planner__
-auto-splitter-block-filter-item-atan-null=[item=atan-null] __ITEM__atan-null__
+auto-splitter-block-filter-item-atan-null=[item=atan-null] __ITEM__atan-null__ (Null Item)
+auto-splitter-block-filter-item-null=[item=null] __ENTITY__null__ (Null)

--- a/settings.lua
+++ b/settings.lua
@@ -9,7 +9,10 @@ local setting = {
 
 if mods["atan-null"] then
   table.insert(setting.allowed_values, "atan-null")
-  setting.default_value = "atan-null"
+end
+
+if mods["null"] then
+  table.insert(setting.allowed_values, "null")
 end
 
 data:extend({


### PR DESCRIPTION
## Summary
Add support for the Null MOD as a block filter item option, and change the default filter item to always be `no-item`.

## Changes
- Add `null` as an optional dependency
- Add `null` item to allowed filter values when the MOD is present
- Always use `no-item` as default (remove atan-null default override)
- Add MOD display names in parentheses to locale for disambiguation between Null Item and Null MODs
- Use `__ENTITY__null__` instead of `__ITEM__null__` since the Null MOD only defines entity-name locale

Closes #14
