### PR TITLE
:bug: Fix block filter not re-evaluated after clearing on orientation change

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -31,9 +31,8 @@ local function on_entity_orientation_changed(event)
     if not splitter_utils.is_circuit_controlled(entity) then
       if splitter_utils.has_block_filter(entity) then
         splitter_utils.clear_block_filter(entity)
-      elseif not entity.splitter_filter then
-        splitter_utils.update_block_filter(entity)
       end
+      splitter_utils.update_block_filter(entity)
     end
   end
 


### PR DESCRIPTION
## Summary
Fix block filter not being re-evaluated after clearing on splitter orientation change (rotation/flip).

## Changes
- Move `update_block_filter` call outside the conditional block so it always runs after clearing, not only when no filter exists
- Remove unnecessary empty `elseif` branch since `update_block_filter` already checks for user-configured filters internally

Fixes #16
